### PR TITLE
Fixed bug that caused only one colour bundle to be used

### DIFF
--- a/datageneration/property_generator.py
+++ b/datageneration/property_generator.py
@@ -18,11 +18,9 @@ def fetch_color_bundle(property_examples: List[TagPropertyExample], bundle_path:
         color_bundles.append(ColorBundle(descriptors = [x.strip() for x in color_bundle['Colour Descriptors'].split(',')],
                     color_values = [x.strip() for x in color_bundle['Colour Descriptors'].split(',')]))
 
-
     for color_example in color_examples:
         color_example_key = color_example['key']
         related_color_examples = color_example['examples']
-
 
         related_colors = []
         for related_color_example in related_color_examples:

--- a/datageneration/retrieve_combinations.py
+++ b/datageneration/retrieve_combinations.py
@@ -276,6 +276,7 @@ class CombinationRetriever(object):
             tuple(bool, int): True and its index in self.tag_properties, False and its index -1 otherwise.
         '''
         exists = False
+        results = []
         for tag_prop_idx, tag_prop in enumerate(self.tag_properties):
             for tag_prop_tag in tag_prop.tags:
                 tag_prop_tag_value = tag_prop_tag.value
@@ -283,12 +284,16 @@ class CombinationRetriever(object):
                     tag_prop_tag_value = ''
                 if f'{tag_prop_tag.key}{tag_prop_tag.operator}{tag_prop_tag_value}' == other_tag:
                     exists = True
-                    return (exists, tag_prop_idx)
+                    results.append(tag_prop_idx)
+                    # return (exists, tag_prop_idx)
                 elif f'{tag_prop_tag.key}{tag_prop_tag.operator}' == other_tag:
                     exists = True
-                    return (exists, tag_prop_idx)
-
-        return (exists, -1)
+                    results.append(tag_prop_idx)
+                    # return (exists, tag_prop_idx)
+        if exists:
+            return (exists, results)
+        else:
+            return (exists, -1)
 
     def request_related_tag_properties(self, tag_key: str, tag_value: str, limit: int = 100) -> List[TagProperty]:
         combinations = request_tag_combinations(tag_key=tag_key, tag_value=tag_value)['data']
@@ -298,14 +303,15 @@ class CombinationRetriever(object):
                 return list(selected_properties)
 
             for seperator in SEPERATORS:
-                exist_property, prop_index = self.check_other_tag_in_properties(
+                exist_property, prop_indices = self.check_other_tag_in_properties(
                     other_tag=combination['other_key'] + seperator + combination['other_value'])
                 if exist_property:
                     break
 
             if exist_property:
-                fetched_tag_prop = self.tag_properties[prop_index]
-                selected_properties.append(fetched_tag_prop)
+                for prop_index in prop_indices:
+                    fetched_tag_prop = self.tag_properties[prop_index]
+                    selected_properties.append(fetched_tag_prop)
             # else:
             #     print(f'{combination} does not exist')
             #     if (combination['other_key'] in self.numeric_tags_properties_ids and

--- a/scripts/generate_combinations.sh
+++ b/scripts/generate_combinations.sh
@@ -156,10 +156,10 @@ python -m datageneration.generate_combination_table \
 --prob_of_two_word_areas 0.5 \
 --prob_generating_contain_rel 0.4 \
 --prob_of_numerical_properties 0.2 \
---prob_of_color_properties 0.2 \
---prob_of_rare_non_numerical_properties 0.2 \
---prob_of_other_non_numerical_properties 0.2 \
---prob_of_popular_non_numerical_properties 0.2 \
+--prob_of_color_properties 0.5 \
+--prob_of_rare_non_numerical_properties 0.1 \
+--prob_of_other_non_numerical_properties 0.1 \
+--prob_of_popular_non_numerical_properties 0.1 \
 --prob_adding_brand_names_as_entity 0.05 \
 --prob_of_non_roman_areas 0.2 \
 --prob_of_cluster_entities 0.5 \

--- a/scripts/generate_samples_with_gpt.sh
+++ b/scripts/generate_samples_with_gpt.sh
@@ -66,5 +66,5 @@ python -m datageneration.gpt_data_generator \
 --prob_of_typos 0.4 \
 --max_dist_digits 5 \
 --save_yaml_csv \
---generate_prompts \
---generate_sentences
+--generate_prompts #\
+#--generate_sentences


### PR DESCRIPTION
Fixed bug that caused only one colour bundle to be used in the training data.

Reason was the way possible combinations were assigned in the combination retrieval step, which previously only allowed one bundle per tag to be extracted. Fixed it to retrieve all bundles a tag belongs to.